### PR TITLE
Support vsis3

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,8 +8,10 @@ services:
     ports:
       - "8080:8080"
     environment:
-      PROXY_HOSTNAME: "sentinel-cogs.s3.amazonaws.com"
+      PROXY_HOSTNAME: "usgs-landsat.s3.amazonaws.com"
       GROUPCACHE_PEERS: "http://app1:8080,http://app2:8080,http://app3:8080"
+    dns:
+      - 8.8.8.8
   app2:
     build:
       context: .
@@ -18,8 +20,10 @@ services:
     ports:
       - "8081:8080"
     environment:
-      PROXY_HOSTNAME: "sentinel-cogs.s3.amazonaws.com"
+      PROXY_HOSTNAME: "usgs-landsat.s3.amazonaws.com"
       GROUPCACHE_PEERS: "http://app2:8080,http://app1:8080,http://app3:8080"
+    dns:
+      - 8.8.8.8
   app3:
     build:
       context: .
@@ -28,11 +32,13 @@ services:
     ports:
       - "8082:8080"
     environment:
-      PROXY_HOSTNAME: "sentinel-cogs.s3.amazonaws.com"
+      PROXY_HOSTNAME: "usgs-landsat.s3.amazonaws.com"
       GROUPCACHE_PEERS: "http://app3:8080,http://app1:8080,http://app2:8080"
+    dns:
+      - 8.8.8.8
   nginx:
     image: nginx
     ports:
-      - "8000:80"
+      - "80:80"
     volumes:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"os"
 	"bytes"
@@ -32,9 +33,24 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 		log.Fatal(err)
 	}
 
+	// "Sanitize" request for use as key by removing headers that will change w/ each request
+	reqReader := bufio.NewReader(strings.NewReader(b.String()))
+	parsedRequest, err := http.ReadRequest(reqReader)
+	if err != nil {
+		log.Panic(err)
+	}
+	parsedRequest.Header.Del("X-Amz-Date")
+	parsedRequest.Header.Del("X-Amz-Content-Sha256") // This one could probably just be left
+	parsedRequest.Header.Del("Authorization")
+
+	dump, err := httputil.DumpRequest(parsedRequest, true)
+	if err != nil {
+		panic(err)
+	}
+
 	// Hit the cache
 	var data []byte
-	if err := group.Get(r.Context(), b.String(), groupcache.AllocatingByteSliceSink(&data)); err != nil {
+	if err := group.Get(context.WithValue(r.Context(), "orig_request", b.String()), string(dump), groupcache.AllocatingByteSliceSink(&data)); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -51,7 +67,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(res.StatusCode)
 	io.Copy(w, res.Body)
 	res.Body.Close()
-}	
+}
 
 func newPool(peers []string) *groupcache.HTTPPool {
 	pool := groupcache.NewHTTPPoolOpts(peers[0], nil)
@@ -64,25 +80,30 @@ var group *groupcache.Group
 
 func newGroup(hostName string, cacheSizeBytes int64) {
 	group = groupcache.NewGroup("requests", cacheSizeBytes, groupcache.GetterFunc(
-		func(_ context.Context, key string, sink groupcache.Sink) error {
+		func(ctx context.Context, key string, sink groupcache.Sink) error {
 			me, err := os.Hostname()
 			if err != nil {
 				log.Panic(err)
 			}
-	
+
 			log.Printf("Request handled by %s", me)
-	
-			// Rebuild HTTP request from cache key
-			reader := bufio.NewReader(strings.NewReader(key))
+
+			// Rebuild HTTP request from orig_request context
+			origRequestString, ok := ctx.Value("orig_request").(string)
+			if !ok {
+				log.Panic("Can't get original request from context")
+			}
+			log.Println(origRequestString)
+			reader := bufio.NewReader(strings.NewReader(origRequestString))
 			originalRequest, err := http.ReadRequest(reader)
 			if err != nil {
 				log.Panic(err)
 			}
-	
+
 			// We can't have this set on client requests
 			originalRequest.RequestURI = ""
-	
-			rawURL := "http://" + hostName
+
+			rawURL := "https://" + hostName
 			if originalRequest.URL.Path != "" {
 				rawURL = rawURL + originalRequest.URL.Path
 			}
@@ -92,13 +113,13 @@ func newGroup(hostName string, cacheSizeBytes int64) {
 			}
 			originalRequest.URL = fullUrl
 			originalRequest.Host = hostName
-	
+
 			client := http.Client{}
 			res, err := client.Do(originalRequest)
 			if err != nil {
 				log.Panic(err)
 			}
-	
+
 			// Write HTTP response out to bytes, store in cache
 			var outBuf bytes.Buffer
 			if err := res.Write(&outBuf); err != nil {
@@ -107,7 +128,7 @@ func newGroup(hostName string, cacheSizeBytes int64) {
 			sink.SetBytes(outBuf.Bytes(), time.Time{})
 			return nil
 		},
-	))	
+	))
 }
 
 
@@ -128,12 +149,9 @@ func main() {
 		log.Fatal("Missing required env variable GROUPCACHE_PEERS")
 	}
 
-
-
 	// Setup groupcache
 	newGroup(proxyHostname, cacheSizeBytes)
 	peersList := strings.Split(cachePeers, ",")
-	
 
 	log.Printf("listening on %v", peersList[0])
 	log.Printf("peers: %v", peersList)


### PR DESCRIPTION
Proof of concept of how this could potentially support `/vsis3/` or, more broadly, signed requests in general. Two things need to happen to make it work:
1. We need to make sure the `Host` header doesn't get changed by the proxy, otherwise the HMAC signature in the `Authorization` header wont be valid.
2. Since the raw HTTP request is used as the hash key, we need to strip out headers that will change between otherwise equivalent requests or we'll never get any cache hits.

To test this out I used data in the `usgs-landsat` bucket, which requires authentication since it only allows "requester pays":
```
CPL_CURL_VERBOSE=YES \
GDAL_DISABLE_READDIR_ON_OPEN=TRUE \
CPL_VSIL_CURL_ALLOWED_EXTENSIONS=.tif \
AWS_HTTPS=no \
AWS_REQUEST_PAYER=requester \
gdalinfo /vsis3/usgs-landsat/collection02/level-2/standard/oli-tirs/2025/086/075/LC09_L2SR_086075_20250501_20250502_02_T2/LC09_L2SR_086075_20250501_20250502_02_T2_SR_B2.TIF
```

On point 1 my approach was to use DNS to "trick" the client into resolving the real hostname to the IP address of the proxy. For testing locally I just made an entry for `usgs-landsat.s3.amazonaws.com` pointing to `127.0.0.1` in my `/etc/hosts` file. I found that on my machine the containers were picking up DNS configuration from the host,  so I had to explicitly configure DNS in `docker-compose.yaml` so that they could still resolve the real IP for AWS. I also had to ensure nginx was forwarded to port `80` because I haven no idea how to tell GDAL to use a non-standard port with `vsis3`.

Another (possibly more straightforward) way to accomplish the same goal might be to use the `GDAL_HTTP_PROXY` environment variable, but I just couldn't get that to work.

On point 2 I updated the code to remove  `Authorization` and `X-Amz-Date` before sending the request over to `groupcache` to use as the cache key. I also stripped out `X-Amz-Content-Sha256` but I don't think that's strictly necessary.

The tricky part is that while it's important those headers are *not* included in the key, we still need to have them available so we can make the request to S3 in the case of a cache miss. The only way I could find to pass additional data into the `GetterFunc` was by using `Context`. But that's kinda janky as the context is not passed between peers. So what I'm seeing is that when a brand new request comes in `groupcache` will reach out to its peers, and since they don't have it either one of them will try to fulfill the request, but that will fail because the peers don't have the context. Ultimately, though, since the first one doesn't get a response back from any of its peers it will go ahead and fulfill the request itself. So there is a bunch of ugliness in the logs, but seems to work.

